### PR TITLE
#51 - bug fix for (accidentally) removed config file

### DIFF
--- a/cli/kaos_cli/utils/decorators.py
+++ b/cli/kaos_cli/utils/decorators.py
@@ -118,6 +118,12 @@ def init_check(func):
                 click.style(os.path.split(KAOS_STATE_DIR)[-1], bold=True, fg='red'),
                 click.style("kaos init", bold=True, fg='green')))
             sys.exit(1)
+        if not os.path.exists(CONFIG_PATH):
+            click.echo("{} - {} does not exist - run {}".format(
+                click.style("Warning", bold=True, fg='yellow'),
+                click.style("./kaos/config", bold=True, fg='red'),
+                click.style("kaos init", bold=True, fg='green')))
+            sys.exit(1)
         func(*args, **kwargs)
 
     return wrapper


### PR DESCRIPTION
### Description
Bug fix for checking whether the kaos `config` exists (since we previously only checked for `./.kaos`. This work closes #51

### Checklist

- [x] An issue was first created **before** opening this pull request
- [x] The new code follows the kaos [contribution guidelines](CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
