### PR TITLE
[WIP]: k-14: select and use kaos context from a list of contexts

### DIFF
--- a/cli/kaos_cli/__init__.py
+++ b/cli/kaos_cli/__init__.py
@@ -10,6 +10,9 @@ from .commands.train import train
 from .commands.workspace import workspace
 from .utils.custom_classes import CustomHelpOrder
 
+from configparser import ConfigParser, ExtendedInterpolation
+from kaos_cli.constants import DEFAULTS, CONFIG_PATH
+
 
 @click.group(cls=CustomHelpOrder)
 @click.pass_context
@@ -24,15 +27,21 @@ def kaos(ctx):
 ╚═╝  ╚═╝╚═╝  ╚═╝ ╚═════╝ ╚══════╝
 \b
 
-Open source cloud agnostic minimal DevOps private versioned ML platform.
+Open source cloud agnostic minimal DevOps private versoned ML platform.
 
     """
 
+    # derive current context from config
+    print("debug here")
+    config = ConfigParser(defaults=DEFAULTS, interpolation=ExtendedInterpolation())
+    config.read(CONFIG_PATH)
+    active_context = config.get("contexts", "active_context")
     factory = SimpleFactory()
-    factory.create()
+    factory.create(active_context)
     ctx.obj = factory
 
 
+# Creating kaos context adding commands
 kaos.add_command(build)
 kaos.add_command(destroy)
 kaos.add_command(init)

--- a/cli/kaos_cli/__init__.py
+++ b/cli/kaos_cli/__init__.py
@@ -32,12 +32,11 @@ Open source cloud agnostic minimal DevOps private versoned ML platform.
     """
 
     # derive current context from config
-    print("debug here")
-    config = ConfigParser(defaults=DEFAULTS, interpolation=ExtendedInterpolation())
-    config.read(CONFIG_PATH)
-    active_context = config.get("contexts", "active_context")
+    # config = ConfigParser(defaults=DEFAULTS, interpolation=ExtendedInterpolation())
+    # config.read(CONFIG_PATH)
+    # active_context = config.get("contexts", "active_context")
     factory = SimpleFactory()
-    factory.create(active_context)
+    factory.create()
     ctx.obj = factory
 
 

--- a/cli/kaos_cli/commands/build.py
+++ b/cli/kaos_cli/commands/build.py
@@ -2,12 +2,11 @@ import os
 import sys
 
 import click
-from kaos_cli.constants import AWS, GCP, DOCKER, MINIKUBE
+from kaos_cli.constants import AWS, GCP, DOCKER, MINIKUBE, KAOS_STATE_DIR
 from kaos_cli.utils.validators import validate_build_env
 from kaos_cli.exceptions.handle_exceptions import handle_specific_exception, handle_exception
 from kaos_cli.facades.backend_facade import BackendFacade, is_cloud_provider
 from kaos_cli.utils.decorators import build_env_check, pass_obj
-from kaos_cli.constants import AWS, GCP, DOCKER, MINIKUBE, KAOS_STATE_DIR
 from kaos_cli.utils.helpers import build_dir
 from kaos_cli.utils.decorators import in_dir
 
@@ -43,29 +42,24 @@ def build(cloud, env, force, verbose, yes, local_backend):
     # Creating build directory
     build_dir(dir_build)
 
-    # validate ENV
-    env = validate_build_env(cloud, env)
-
     @in_dir(dir_build)
     @pass_obj(BackendFacade)
     def __build_backend(backend: BackendFacade, cloud, env, force, verbose, yes, local_backend, dir_build):
 
-        print("cloud", cloud)
-        print("env", env)
-        print("force", force)
-        print("verbose", verbose)
-        print("local_backend", local_backend)
-
         is_created = backend.is_created()
 
         if is_created and not force:
-            click.echo('Aborting! - {} backend is already built.'.format(click.style("kaos", bold=True, fg='red')))
+            click.echo('{} - {} backend is already built.'.format(click.style("Aborting", bold=True, fg='red'),
+                                                                  click.style("kaos", bold=True)))
             sys.exit(1)
 
         elif is_created and force:
             click.echo('{} - Performing {} build of the backend'.format(
                 click.style("Warning", bold=True, fg='yellow'),
                 click.style("force", bold=True)))
+
+        # validate ENV
+        env = validate_build_env(cloud, env)
 
         if not yes:
             # confirm creation of backend
@@ -78,7 +72,6 @@ def build(cloud, env, force, verbose, yes, local_backend):
                         click.style(cloud, bold=True, fg='red')),
                     abort=True)
             else:
-                print("debug******")
                 click.confirm(
                     '{} - Are you sure about building {} backend in {}?'.format(
                         click.style("Warning", bold=True, fg='yellow'),
@@ -111,20 +104,12 @@ def build(cloud, env, force, verbose, yes, local_backend):
                            .format(click.style("Info", bold=True, fg='green'),
                                    click.style("export KUBECONFIG=" + kubeconfig,
                                                bold=True, fg='red')))
-
-            click.echo("Successfully built {} [{}] environment".format(click.style('kaos', bold=True, fg='green'),
-                                                                       click.style(env, bold=True, fg='blue')))
-
-            print("Azhor")
-
             if env:
-                print("Prince")
                 click.echo("{} - Successfully built {} [{}] environment".format(
                     click.style("Info", bold=True, fg='green'),
                     click.style('kaos', bold=True),
                     click.style(env, bold=True, fg='blue')))
             else:
-                print("Ahai")
                 click.echo("{} - Successfully built {} environment".format(
                     click.style("Info", bold=True, fg='green'),
                     click.style('kaos', bold=True)))
@@ -157,20 +142,22 @@ def destroy(cloud, env, verbose, yes):
 
     dir_build = os.path.join(KAOS_STATE_DIR, build_path)
 
-    # validate ENV
-    env = validate_build_env(cloud, env)
-
     @in_dir(dir_build)
     @pass_obj(BackendFacade)
     def __destroy_backend(backend: BackendFacade, cloud, env, dir_build, verbose, yes):
+
+        # validate ENV
+        env = validate_build_env(cloud, env)
+
         if not yes:
             # confirm creation of backend
             if env:
-                click.confirm('{} - Are you sure about destroying {} [{}] backend in {}?'.format(
-                    click.style("Warning", bold=True, fg='yellow'),
-                    click.style('kaos', bold=True),
-                    click.style(env, bold=True, fg='blue'),
-                    click.style(cloud, bold=True, fg='red')),
+                click.confirm(
+                    '{} - Are you sure about destroying {} [{}] backend in {}?'.format(
+                        click.style("Warning", bold=True, fg='yellow'),
+                        click.style('kaos', bold=True),
+                        click.style(env, bold=True, fg='blue'),
+                        click.style(cloud, bold=True, fg='red')),
                     abort=True)
             else:
                 click.confirm(
@@ -192,7 +179,6 @@ def destroy(cloud, env, verbose, yes):
                 click.echo(
                     "{} - Successfully destroyed {} environment".format(click.style("Info", bold=True, fg='green'),
                                                                         click.style('kaos', bold=True)))
-
         except Exception as e:
             handle_specific_exception(e)
             handle_exception(e)

--- a/cli/kaos_cli/commands/build.py
+++ b/cli/kaos_cli/commands/build.py
@@ -43,9 +43,19 @@ def build(cloud, env, force, verbose, yes, local_backend):
     # Creating build directory
     build_dir(dir_build)
 
+    # validate ENV
+    env = validate_build_env(cloud, env)
+
     @in_dir(dir_build)
     @pass_obj(BackendFacade)
     def __build_backend(backend: BackendFacade, cloud, env, force, verbose, yes, local_backend, dir_build):
+
+        print("cloud", cloud)
+        print("env", env)
+        print("force", force)
+        print("verbose", verbose)
+        print("local_backend", local_backend)
+
         is_created = backend.is_created()
 
         if is_created and not force:
@@ -56,9 +66,6 @@ def build(cloud, env, force, verbose, yes, local_backend):
             click.echo('{} - Performing {} build of the backend'.format(
                 click.style("Warning", bold=True, fg='yellow'),
                 click.style("force", bold=True)))
-
-        # validate ENV
-        env = validate_build_env(cloud, env)
 
         if not yes:
             # confirm creation of backend
@@ -71,6 +78,7 @@ def build(cloud, env, force, verbose, yes, local_backend):
                         click.style(cloud, bold=True, fg='red')),
                     abort=True)
             else:
+                print("debug******")
                 click.confirm(
                     '{} - Are you sure about building {} backend in {}?'.format(
                         click.style("Warning", bold=True, fg='yellow'),
@@ -107,12 +115,16 @@ def build(cloud, env, force, verbose, yes, local_backend):
             click.echo("Successfully built {} [{}] environment".format(click.style('kaos', bold=True, fg='green'),
                                                                        click.style(env, bold=True, fg='blue')))
 
+            print("Azhor")
+
             if env:
+                print("Prince")
                 click.echo("{} - Successfully built {} [{}] environment".format(
                     click.style("Info", bold=True, fg='green'),
                     click.style('kaos', bold=True),
                     click.style(env, bold=True, fg='blue')))
             else:
+                print("Ahai")
                 click.echo("{} - Successfully built {} environment".format(
                     click.style("Info", bold=True, fg='green'),
                     click.style('kaos', bold=True)))

--- a/cli/kaos_cli/commands/build.py
+++ b/cli/kaos_cli/commands/build.py
@@ -1,12 +1,14 @@
 import os
 import sys
+import time
 
 import click
-from kaos_cli.constants import AWS, GCP, DOCKER, MINIKUBE
 from kaos_cli.exceptions.handle_exceptions import handle_specific_exception, handle_exception
 from kaos_cli.facades.backend_facade import BackendFacade, is_cloud_provider
 from kaos_cli.utils.decorators import build_env_check, pass_obj
-from kaos_cli.utils.validators import validate_build_env
+from kaos_cli.constants import AWS, GCP, DOCKER, MINIKUBE, KAOS_STATE_DIR
+from kaos_cli.utils.helpers import build_dir
+from kaos_cli.utils.decorators import in_dir
 
 
 # BUILD command
@@ -15,95 +17,79 @@ from kaos_cli.utils.validators import validate_build_env
                short_help='{}'.format(
                    click.style('Build the kaos backend', bold=True, fg='black')))
 @click.option('-c', '--cloud', type=click.Choice([DOCKER, MINIKUBE, AWS, GCP]),
-              help='selected provider', required=True)
-@click.option('-e', '--env', type=click.Choice(['prod', 'stage', 'dev']),
-              help='selected environment [cloud only]', required=False)
+              help='selected provider provider', required=True)
+@click.option('-e', '--env', type=click.Choice(['prod', 'stage', 'dev']), default='prod',
+              help='selected infrastructure environment', required=False)
 @click.option('-f', '--force', is_flag=True,
-              help='force build', required=False)
+              help='force building infrastructure', required=False)
 @click.option('-v', '--verbose', is_flag=True,
               help='verbose output', required=False)
 @click.option('-y', '--yes', is_flag=True,
               help='answer yes to any prompt', required=False)
 @click.option('-l', '--local_backend', is_flag=True,
-              help='locally store terraform state [cloud only]', required=False)
+              help='terraform will store backend locally, only relevant for AWS and GCP', required=False)
 @build_env_check
-@pass_obj(BackendFacade)
-def build(backend: BackendFacade, cloud, env, force, verbose, yes, local_backend):
+def build(cloud, env, force, verbose, yes, local_backend):
     """
-    Deploy kaos backend infrastructure based on selected provider provider.
+    Deploy kaos backend infrastructure based on selected provider.
     """
-    is_created = backend.is_created()
 
-    if is_created and not force:
-        click.echo('{} - {} backend is already built.'.format(click.style("Aborting", bold=True, fg='red'),
-                                                              click.style("kaos", bold=True)))
-        sys.exit(1)
+    # Computing kaos state directory based on cloud and env before destroy
+    build_path = f"state/{cloud}/{env}/" if cloud not in [DOCKER, MINIKUBE] else f"state/{cloud}/local/"
 
-    elif is_created and force:
-        click.echo('{} - Performing {} build of the backend'.format(
-            click.style("Warning", bold=True, fg='yellow'),
-            click.style("force", bold=True)))
+    dir_build = os.path.join(KAOS_STATE_DIR, build_path)
 
-    # validate ENV
-    env = validate_build_env(cloud, env)
+    # Creating build directory
+    build_dir(dir_build)
 
-    if not yes:
-        # confirm creation of backend
-        if env:
+    @in_dir(dir_build)
+    @pass_obj(BackendFacade)
+    def __build_backend(backend: BackendFacade, cloud, env, force, verbose, yes, local_backend, dir_build):
+        is_created = backend.is_created()
+
+        if is_created and not force:
+            click.echo('Aborting! - {} backend is already built.'.format(click.style("kaos", bold=True, fg='red')))
+            sys.exit(1)
+
+        elif is_created and force:
+            click.echo('Performing force build of the backend')
+
+        if not yes:
+            # confirm creation of backend
             click.confirm(
-                '{} - Are you sure about building {} [{}] backend in {}?'.format(
-                    click.style("Warning", bold=True, fg='yellow'),
-                    click.style('kaos', bold=True),
-                    click.style(env, bold=True, fg='blue'),
-                    click.style(cloud, bold=True, fg='red')),
-                abort=True)
-        else:
-            click.confirm(
-                '{} - Are you sure about building {} backend in {}?'.format(
-                    click.style("Warning", bold=True, fg='yellow'),
-                    click.style('kaos', bold=True),
-                    click.style(cloud, bold=True, fg='red')),
+                'Are you sure about building {} [{}] backend in {}?'.format(click.style('kaos', bold=True, fg='green'),
+                                                                            click.style(env, bold=True, fg='blue'),
+                                                                            click.style(cloud, bold=True, fg='red')),
                 abort=True)
 
-    if local_backend:
-        click.echo('{} - Building with {} terraform backend state'.format(
-            click.style("Info", bold=True, fg='green'),
-            click.style("local", bold=True)))
+        if local_backend:
+            click.echo('Building with local backend! The terraform state exists only on this local machine!')
 
-    if local_backend and cloud in [DOCKER, MINIKUBE]:
-        click.echo('{} - local backend (-l/--local_backend) has no effect for {}'.format(
-            click.style("Info", bold=True, fg='green'),
-            click.style(cloud, bold=True, fg='red')))
+        if local_backend and cloud in [DOCKER, MINIKUBE]:
+            click.echo(f'-l/--local_backend flag has been specified but cloud type is {cloud}, '
+                       f'the flag has no effect as the backend is always local in this case.')
 
-    try:
+        try:
 
-        backend.build(cloud, env, local_backend=local_backend, verbose=verbose)
+            backend.build(cloud, env, dir_build, local_backend=local_backend, verbose=verbose)
 
-        if verbose:
-            click.echo("\n{} - Endpoint successfully set to {}".format(
-                click.style("Info", bold=True, fg='green'),
-                click.style(backend.url, bold=True, fg='green')))
+            if verbose:
+                click.echo("Endpoint successfully set to {}".format(click.style(backend.url, bold=True, fg='green')))
 
-        if is_cloud_provider(cloud):
-            kubeconfig = os.path.abspath(backend.kubeconfig)
-            click.echo("\n{} - To interact with the Kubernetes cluster:\n {}"
-                       .format(click.style("Info", bold=True, fg='green'),
-                               click.style("export KUBECONFIG=" + kubeconfig,
-                                           bold=True, fg='red')))
+            if is_cloud_provider(cloud):
+                kubeconfig = os.path.abspath(backend.kubeconfig)
+                click.echo("To interact with the Kubernetes cluster:\n\n {}"
+                           .format(click.style("export KUBECONFIG=" + kubeconfig,
+                                               bold=True, fg='red')))
 
-        if env:
-            click.echo("{} - Successfully built {} [{}] environment".format(
-                click.style("Info", bold=True, fg='green'),
-                click.style('kaos', bold=True),
-                click.style(env, bold=True, fg='blue')))
-        else:
-            click.echo("{} - Successfully built {} environment".format(
-                click.style("Info", bold=True, fg='green'),
-                click.style('kaos', bold=True)))
+            click.echo("Successfully built {} [{}] environment".format(click.style('kaos', bold=True, fg='green'),
+                                                                       click.style(env, bold=True, fg='blue')))
 
-    except Exception as e:
-        handle_specific_exception(e)
-        handle_exception(e)
+        except Exception as e:
+            handle_specific_exception(e)
+            handle_exception(e)
+
+    __build_backend(cloud, env, force, verbose, yes, local_backend, dir_build)
 
 
 @click.command(name='destroy',
@@ -111,53 +97,44 @@ def build(backend: BackendFacade, cloud, env, force, verbose, yes, local_backend
                    click.style('Destroy the kaos backend', bold=True, fg='black')))
 @click.option('-c', '--cloud', type=click.Choice([DOCKER, MINIKUBE, AWS, GCP]),
               help='selected provider provider', required=True)
-@click.option('-e', '--env', type=click.Choice(['prod', 'stage', 'dev']),
-              help='selected infrastructure environment', required=False)
+@click.option('-e', '--env', type=click.Choice(['prod', 'stage', 'dev']), default='prod',
+              help='selected infrastructure environment', required=True)
 @click.option('-v', '--verbose', is_flag=True,
               help='verbose output', required=False)
 @click.option('-y', '--yes', is_flag=True,
               help='answer yes to any prompt', required=False)
 @build_env_check
-@pass_obj(BackendFacade)
-def destroy(backend: BackendFacade, cloud, env, verbose, yes):
+def destroy(cloud, env, verbose, yes):
     """
     Destroy kaos backend infrastructure based on selected provider.
     """
+    # Computing kaos state directory based on cloud and env before destroy
+    build_path = f"state/{cloud}/{env}/" if cloud not in [DOCKER, MINIKUBE] else f"state/{cloud}/local/"
 
-    # validate ENV
-    env = validate_build_env(cloud, env)
+    dir_build = os.path.join(KAOS_STATE_DIR, build_path)
 
-    if not yes:
-        # confirm creation of backend
-        if env:
+    @in_dir(dir_build)
+    @pass_obj(BackendFacade)
+    def __destroy_backend(backend: BackendFacade, cloud, env, dir_build, verbose, yes):
+        if not yes:
+            # confirm creation of backend
             click.confirm(
-                '{} - Are you sure about destroying {} [{}] backend in {}?'.format(
-                    click.style("Warning", bold=True, fg='yellow'),
-                    click.style('kaos', bold=True),
+                'Are you sure about destroying {} [{}] backend in {}?'.format(
+                    click.style('kaos', bold=True, fg='green'),
                     click.style(env, bold=True, fg='blue'),
                     click.style(cloud, bold=True, fg='red')),
                 abort=True)
-        else:
-            click.confirm(
-                '{} - Are you sure about destroying {} backend in {}?'.format(
-                    click.style("Warning", bold=True, fg='yellow'),
-                    click.style('kaos', bold=True),
-                    click.style(cloud, bold=True, fg='red')),
-                abort=True)
-    try:
 
-        backend.destroy(cloud, env, verbose=verbose)
+        try:
 
-        if env:
-            click.echo(
-                "{} - Successfully destroyed {} [{}] environment".format(click.style("Info", bold=True, fg='green'),
-                                                                         click.style('kaos', bold=True),
-                                                                         click.style(env, bold=True, fg='blue')))
-        else:
-            click.echo(
-                "{} - Successfully destroyed {} environment".format(click.style("Info", bold=True, fg='green'),
-                                                                    click.style('kaos', bold=True)))
+            backend.destroy(cloud, env, dir_build, verbose=verbose)
 
-    except Exception as e:
-        handle_specific_exception(e)
-        handle_exception(e)
+            click.echo("Successfully destroyed {} [{}] environment".format(click.style('kaos', bold=True, fg='green'),
+                                                                           click.style(env, bold=True, fg='blue')))
+
+        except Exception as e:
+            handle_specific_exception(e)
+            handle_exception(e)
+
+    __destroy_backend(cloud, env, dir_build, verbose, yes)
+

--- a/cli/kaos_cli/commands/build.py
+++ b/cli/kaos_cli/commands/build.py
@@ -9,7 +9,6 @@ from kaos_cli.facades.backend_facade import BackendFacade, is_cloud_provider
 from kaos_cli.utils.decorators import build_env_check, pass_obj
 from kaos_cli.utils.helpers import build_dir
 from kaos_cli.utils.decorators import in_dir
-from kaos_cli.factories.simple_factory import SimpleFactory
 
 
 # BUILD command
@@ -45,11 +44,10 @@ def build(cloud, env, force, verbose, yes, local_backend):
 
     # creating backend_identifier based on deployment environment
     env = "local" if cloud in [DOCKER, MINIKUBE] else env
-    backend_identifier = cloud + '_' + env
 
     @in_dir(dir_build)
     @pass_obj(BackendFacade)
-    def __build_backend(backend: BackendFacade, cloud, env, force, verbose, yes, local_backend, dir_build, backend_identifier):
+    def __build_backend(backend: BackendFacade, cloud, env, force, verbose, yes, local_backend, dir_build):
 
         is_created = backend.is_created(dir_build)
 
@@ -64,16 +62,16 @@ def build(cloud, env, force, verbose, yes, local_backend):
                 click.style("force", bold=True)))
 
         # validate ENV
-        env = validate_build_env(cloud, env)
+        environment = validate_build_env(cloud, env)
 
         if not yes:
             # confirm creation of backend
-            if env:
+            if environment:
                 click.confirm(
                     '{} - Are you sure about building {} [{}] backend in {}?'.format(
                         click.style("Warning", bold=True, fg='yellow'),
                         click.style('kaos', bold=True),
-                        click.style(env, bold=True, fg='blue'),
+                        click.style(environment, bold=True, fg='blue'),
                         click.style(cloud, bold=True, fg='red')),
                     abort=True)
             else:
@@ -109,11 +107,11 @@ def build(cloud, env, force, verbose, yes, local_backend):
                            .format(click.style("Info", bold=True, fg='green'),
                                    click.style("export KUBECONFIG=" + kubeconfig,
                                                bold=True, fg='red')))
-            if env:
+            if environment:
                 click.echo("{} - Successfully built {} [{}] environment".format(
                     click.style("Info", bold=True, fg='green'),
                     click.style('kaos', bold=True),
-                    click.style(env, bold=True, fg='blue')))
+                    click.style(environment, bold=True, fg='blue')))
             else:
                 click.echo("{} - Successfully built {} environment".format(
                     click.style("Info", bold=True, fg='green'),
@@ -123,7 +121,7 @@ def build(cloud, env, force, verbose, yes, local_backend):
             handle_specific_exception(e)
             handle_exception(e)
 
-    __build_backend(cloud, env, force, verbose, yes, local_backend, dir_build, backend_identifier)
+    __build_backend(cloud, env, force, verbose, yes, local_backend, dir_build)
 
 
 @click.command(name='destroy',
@@ -147,23 +145,24 @@ def destroy(cloud, env, verbose, yes):
 
     dir_build = os.path.join(KAOS_STATE_DIR, build_path)
 
-    backend_identifier = cloud + '_' + env
+    # creating backend_identifier based on deployment environment
+    env = "local" if cloud in [DOCKER, MINIKUBE] else env
 
     @in_dir(dir_build)
-    @pass_obj(BackendFacade(backend_identifier))
-    def __destroy_backend(backend: BackendFacade(backend_identifier), cloud, env, dir_build, verbose, yes):
+    @pass_obj(BackendFacade)
+    def __destroy_backend(backend: BackendFacade, cloud, env, dir_build, verbose, yes):
 
         # validate ENV
-        env = validate_build_env(cloud, env)
+        environment = validate_build_env(cloud, env)
 
         if not yes:
             # confirm creation of backend
-            if env:
+            if environment:
                 click.confirm(
                     '{} - Are you sure about destroying {} [{}] backend in {}?'.format(
                         click.style("Warning", bold=True, fg='yellow'),
                         click.style('kaos', bold=True),
-                        click.style(env, bold=True, fg='blue'),
+                        click.style(environment, bold=True, fg='blue'),
                         click.style(cloud, bold=True, fg='red')),
                     abort=True)
             else:
@@ -177,11 +176,11 @@ def destroy(cloud, env, verbose, yes):
 
             backend.destroy(cloud, env, dir_build, verbose=verbose)
 
-            if env:
+            if environment:
                 click.echo(
                     "{} - Successfully destroyed {} [{}] environment".format(click.style("Info", bold=True, fg='green'),
                                                                              click.style('kaos', bold=True),
-                                                                             click.style(env, bold=True, fg='blue')))
+                                                                             click.style(environment, bold=True, fg='blue')))
             else:
                 click.echo(
                     "{} - Successfully destroyed {} environment".format(click.style("Info", bold=True, fg='green'),

--- a/cli/kaos_cli/commands/build.py
+++ b/cli/kaos_cli/commands/build.py
@@ -1,8 +1,9 @@
 import os
 import sys
-import time
 
 import click
+from kaos_cli.constants import AWS, GCP, DOCKER, MINIKUBE
+from kaos_cli.utils.validators import validate_build_env
 from kaos_cli.exceptions.handle_exceptions import handle_specific_exception, handle_exception
 from kaos_cli.facades.backend_facade import BackendFacade, is_cloud_provider
 from kaos_cli.utils.decorators import build_env_check, pass_obj
@@ -17,21 +18,21 @@ from kaos_cli.utils.decorators import in_dir
                short_help='{}'.format(
                    click.style('Build the kaos backend', bold=True, fg='black')))
 @click.option('-c', '--cloud', type=click.Choice([DOCKER, MINIKUBE, AWS, GCP]),
-              help='selected provider provider', required=True)
-@click.option('-e', '--env', type=click.Choice(['prod', 'stage', 'dev']), default='prod',
-              help='selected infrastructure environment', required=False)
+              help='selected provider', required=True)
+@click.option('-e', '--env', type=click.Choice(['prod', 'stage', 'dev']),
+              help='selected environment [cloud only]', required=False)
 @click.option('-f', '--force', is_flag=True,
-              help='force building infrastructure', required=False)
+              help='force build', required=False)
 @click.option('-v', '--verbose', is_flag=True,
               help='verbose output', required=False)
 @click.option('-y', '--yes', is_flag=True,
               help='answer yes to any prompt', required=False)
 @click.option('-l', '--local_backend', is_flag=True,
-              help='terraform will store backend locally, only relevant for AWS and GCP', required=False)
+              help='locally store terraform state [cloud only]', required=False)
 @build_env_check
 def build(cloud, env, force, verbose, yes, local_backend):
     """
-    Deploy kaos backend infrastructure based on selected provider.
+    Deploy kaos backend infrastructure based on the selected provider.
     """
 
     # Computing kaos state directory based on cloud and env before destroy
@@ -52,38 +53,69 @@ def build(cloud, env, force, verbose, yes, local_backend):
             sys.exit(1)
 
         elif is_created and force:
-            click.echo('Performing force build of the backend')
+            click.echo('{} - Performing {} build of the backend'.format(
+                click.style("Warning", bold=True, fg='yellow'),
+                click.style("force", bold=True)))
+
+        # validate ENV
+        env = validate_build_env(cloud, env)
 
         if not yes:
             # confirm creation of backend
-            click.confirm(
-                'Are you sure about building {} [{}] backend in {}?'.format(click.style('kaos', bold=True, fg='green'),
-                                                                            click.style(env, bold=True, fg='blue'),
-                                                                            click.style(cloud, bold=True, fg='red')),
-                abort=True)
+            if env:
+                click.confirm(
+                    '{} - Are you sure about building {} [{}] backend in {}?'.format(
+                        click.style("Warning", bold=True, fg='yellow'),
+                        click.style('kaos', bold=True),
+                        click.style(env, bold=True, fg='blue'),
+                        click.style(cloud, bold=True, fg='red')),
+                    abort=True)
+            else:
+                click.confirm(
+                    '{} - Are you sure about building {} backend in {}?'.format(
+                        click.style("Warning", bold=True, fg='yellow'),
+                        click.style('kaos', bold=True),
+                        click.style(cloud, bold=True, fg='red')),
+                    abort=True)
 
         if local_backend:
-            click.echo('Building with local backend! The terraform state exists only on this local machine!')
+            click.echo('{} - Building with {} terraform backend state'.format(
+                click.style("Info", bold=True, fg='green'),
+                click.style("local", bold=True)))
 
         if local_backend and cloud in [DOCKER, MINIKUBE]:
-            click.echo(f'-l/--local_backend flag has been specified but cloud type is {cloud}, '
-                       f'the flag has no effect as the backend is always local in this case.')
+            click.echo('{} - local backend (-l/--local_backend) has no effect for {}'.format(
+                click.style("Info", bold=True, fg='green'),
+                click.style(cloud, bold=True, fg='red')))
 
         try:
 
             backend.build(cloud, env, dir_build, local_backend=local_backend, verbose=verbose)
 
             if verbose:
-                click.echo("Endpoint successfully set to {}".format(click.style(backend.url, bold=True, fg='green')))
+                click.echo("\n{} - Endpoint successfully set to {}".format(
+                    click.style("Info", bold=True, fg='green'),
+                    click.style(backend.url, bold=True, fg='green')))
 
             if is_cloud_provider(cloud):
                 kubeconfig = os.path.abspath(backend.kubeconfig)
-                click.echo("To interact with the Kubernetes cluster:\n\n {}"
-                           .format(click.style("export KUBECONFIG=" + kubeconfig,
+                click.echo("\n{} - To interact with the Kubernetes cluster:\n {}"
+                           .format(click.style("Info", bold=True, fg='green'),
+                                   click.style("export KUBECONFIG=" + kubeconfig,
                                                bold=True, fg='red')))
 
             click.echo("Successfully built {} [{}] environment".format(click.style('kaos', bold=True, fg='green'),
                                                                        click.style(env, bold=True, fg='blue')))
+
+            if env:
+                click.echo("{} - Successfully built {} [{}] environment".format(
+                    click.style("Info", bold=True, fg='green'),
+                    click.style('kaos', bold=True),
+                    click.style(env, bold=True, fg='blue')))
+            else:
+                click.echo("{} - Successfully built {} environment".format(
+                    click.style("Info", bold=True, fg='green'),
+                    click.style('kaos', bold=True)))
 
         except Exception as e:
             handle_specific_exception(e)
@@ -96,9 +128,9 @@ def build(cloud, env, force, verbose, yes, local_backend):
                short_help='{}'.format(
                    click.style('Destroy the kaos backend', bold=True, fg='black')))
 @click.option('-c', '--cloud', type=click.Choice([DOCKER, MINIKUBE, AWS, GCP]),
-              help='selected provider provider', required=True)
-@click.option('-e', '--env', type=click.Choice(['prod', 'stage', 'dev']), default='prod',
-              help='selected infrastructure environment', required=True)
+              help='selected provider', required=True)
+@click.option('-e', '--env', type=click.Choice(['prod', 'stage', 'dev']),
+              help='selected infrastructure environment', required=False)
 @click.option('-v', '--verbose', is_flag=True,
               help='verbose output', required=False)
 @click.option('-y', '--yes', is_flag=True,
@@ -113,24 +145,41 @@ def destroy(cloud, env, verbose, yes):
 
     dir_build = os.path.join(KAOS_STATE_DIR, build_path)
 
+    # validate ENV
+    env = validate_build_env(cloud, env)
+
     @in_dir(dir_build)
     @pass_obj(BackendFacade)
     def __destroy_backend(backend: BackendFacade, cloud, env, dir_build, verbose, yes):
         if not yes:
             # confirm creation of backend
-            click.confirm(
-                'Are you sure about destroying {} [{}] backend in {}?'.format(
-                    click.style('kaos', bold=True, fg='green'),
+            if env:
+                click.confirm('{} - Are you sure about destroying {} [{}] backend in {}?'.format(
+                    click.style("Warning", bold=True, fg='yellow'),
+                    click.style('kaos', bold=True),
                     click.style(env, bold=True, fg='blue'),
                     click.style(cloud, bold=True, fg='red')),
-                abort=True)
-
+                    abort=True)
+            else:
+                click.confirm(
+                    '{} - Are you sure about destroying {} backend in {}?'.format(
+                        click.style("Warning", bold=True, fg='yellow'),
+                        click.style('kaos', bold=True),
+                        click.style(cloud, bold=True, fg='red')),
+                    abort=True)
         try:
 
             backend.destroy(cloud, env, dir_build, verbose=verbose)
 
-            click.echo("Successfully destroyed {} [{}] environment".format(click.style('kaos', bold=True, fg='green'),
-                                                                           click.style(env, bold=True, fg='blue')))
+            if env:
+                click.echo(
+                    "{} - Successfully destroyed {} [{}] environment".format(click.style("Info", bold=True, fg='green'),
+                                                                             click.style('kaos', bold=True),
+                                                                             click.style(env, bold=True, fg='blue')))
+            else:
+                click.echo(
+                    "{} - Successfully destroyed {} environment".format(click.style("Info", bold=True, fg='green'),
+                                                                        click.style('kaos', bold=True)))
 
         except Exception as e:
             handle_specific_exception(e)

--- a/cli/kaos_cli/factories/simple_factory.py
+++ b/cli/kaos_cli/factories/simple_factory.py
@@ -14,9 +14,9 @@ class SimpleFactory:
         self.facades = None
         self.services = None
 
-    def create(self):
+    def create(self, cloud_env):
         self.services = self._create_services()
-        self.facades = self._create_facades(**self.services)
+        self.facades = self._create_facades(cloud_env, **self.services)
 
     def __getitem__(self, name):
         if name in self.facades:
@@ -35,9 +35,9 @@ class SimpleFactory:
         return services
 
     @staticmethod
-    def _create_facades(state=None, terraform=None):
+    def _create_facades(cloud_env, state=None, terraform=None):
         template = TemplateFacade()
-        backend = BackendFacade(state, terraform)
+        backend = BackendFacade(cloud_env, state, terraform)
         workspace = WorkspaceFacade(state)
         train = TrainFacade(state)
         serve = ServeFacade(state)

--- a/cli/kaos_cli/factories/simple_factory.py
+++ b/cli/kaos_cli/factories/simple_factory.py
@@ -14,9 +14,9 @@ class SimpleFactory:
         self.facades = None
         self.services = None
 
-    def create(self, cloud_env):
+    def create(self):
         self.services = self._create_services()
-        self.facades = self._create_facades(cloud_env, **self.services)
+        self.facades = self._create_facades(**self.services)
 
     def __getitem__(self, name):
         if name in self.facades:
@@ -35,9 +35,9 @@ class SimpleFactory:
         return services
 
     @staticmethod
-    def _create_facades(cloud_env, state=None, terraform=None):
+    def _create_facades(state=None, terraform=None):
         template = TemplateFacade()
-        backend = BackendFacade(cloud_env, state, terraform)
+        backend = BackendFacade(state, terraform)
         workspace = WorkspaceFacade(state)
         train = TrainFacade(state)
         serve = ServeFacade(state)

--- a/cli/kaos_cli/services/state_service.py
+++ b/cli/kaos_cli/services/state_service.py
@@ -24,8 +24,8 @@ class StateService:
         self.config.remove_section(section)
 
     @staticmethod
-    def is_created():
-        return os.path.exists(KAOS_STATE_DIR)
+    def is_created(dir_build):
+        return os.path.exists(dir_build)
 
     @staticmethod
     def create():


### PR DESCRIPTION
### Description

This feature allows kaos to run on multiple contexts (deployments).
Also allows user to choose a specific context from a list of available contexts. 

### Checklist

- [ ] An issue was first created **before** opening this pull request
- [ ] The new code follows the kaos [contribution guidelines](CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings