### PR TITLE
#61 - allow users to force build local backend after deploy

### DIFF
--- a/cli/kaos_cli/commands/build.py
+++ b/cli/kaos_cli/commands/build.py
@@ -4,7 +4,6 @@ import sys
 import click
 from kaos_cli.constants import AWS, GCP, DOCKER, MINIKUBE
 from kaos_cli.exceptions.handle_exceptions import handle_specific_exception, handle_exception
-from kaos_cli.facades.workspace_facade import WorkspaceFacade
 from kaos_cli.facades.backend_facade import BackendFacade, is_cloud_provider
 from kaos_cli.utils.decorators import build_env_check, pass_obj
 from kaos_cli.utils.validators import validate_build_env, validate_unused_port
@@ -29,8 +28,7 @@ from kaos_cli.utils.validators import validate_build_env, validate_unused_port
               help='locally store terraform state [cloud only]', required=False)
 @build_env_check
 @pass_obj(BackendFacade)
-@pass_obj(WorkspaceFacade)
-def build(workspace: WorkspaceFacade, backend: BackendFacade, cloud, env, force, verbose, yes, local_backend):
+def build(backend: BackendFacade, cloud, env, force, verbose, yes, local_backend):
     """
     Deploy kaos backend infrastructure based on selected provider.
     """


### PR DESCRIPTION
### Description

Fixes issue #61, which allows users to force build the LOCAL backend on DOCKER after deploy. This fixes a regression issue introduced by #59 which helps Kaos avoid port 80 collision when building backend on DOCKER.

### Checklist

- [x] An issue was first created **before** opening this pull request
- [x] The new code follows the kaos [contribution guidelines](CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests to ensure that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
