### PR TITLE
K-83: Handle unknown exceptions when workspace kill confirmed as N

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ jobs:
         # install cli & build kaos
         - export KAOS_HOME=`pwd`
         - cd cli && pip3 install -e . && kaos && cd ../testing/integration
-        - kaos build -c MINIKUBE -fvy
+        - kaos build deploy -c MINIKUBE -fvy
         - ls -la .
         - cat .kaos/config
         - export AMBASSAROR_POD_NAME=`kubectl get pods | awk '{print $1}' | sed -n -e '/^ambassador/p'`

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,6 +1,6 @@
 # kaos
 
-The kaos core is contained within the backend, allowing users to **leverage flexible language agnostic data pipelines.** 
+The kaos core is contained within a cloud-agnostic backend, allowing users to **leverage flexible language agnostic data pipelines.** 
 
 ### Build
 
@@ -9,17 +9,41 @@ The most effective way to build the backend for development is with kaos [CLI](.
 1. Deploy a local cluster ([Docker Desktop](../infrastructure/docker/README.md))
 
 ```bash
-kaos build -c DOCKER -vf
+kaos build deploy -c DOCKER -vf
 ```
 
-2. Make desired changes to the backend (i.e. development)
-
-3. Re-deploy the local cluster **but** only the changes will be "built" (i.e. the new backend image)
+2. Alternatively, backend infrastructure on a cloud platform can also be deployed (AWS shown below)
 ```bash
-kaos build -c DOCKER -vf
+kaos build deploy -c AWS -vf
 ```
 
-4. Kill the existing backend pod in kubernetes to force the pull policy on a new pod
+3. A list of active backend builds already deployed on kaos can be obtained using
+```bash
+kaos build list
+```
+
+4. The current or active backend build can be determined using 
+```bash
+kaos build active
+```
+
+5. Among the available backends, one can select and set a desired backend environment using
+```bash
+kaos build set -c context_name
+```
+*OR*
+```bash
+kaos build set -i index_number
+```
+
+6. Make desired changes to the backend (i.e. development)
+
+7. Re-deploy the local cluster **but** only the changes will be "built" (i.e. the new backend image)
+```bash
+kaos build deploy -c DOCKER -vf
+```
+
+8. Kill the existing backend pod in kubernetes to force the pull policy on a new pod
 ```bash
 kubectl get pod -l app=kaos-backend -o jsonpath="{.items[0].metadata.name}" | xargs -I {} kubectl delete pod {}
 ```

--- a/cli/kaos_cli/commands/workspace.py
+++ b/cli/kaos_cli/commands/workspace.py
@@ -1,4 +1,5 @@
 import click
+import sys
 
 from kaos_cli.exceptions.handle_exceptions import handle_specific_exception, handle_exception
 from kaos_cli.facades.workspace_facade import WorkspaceFacade
@@ -196,22 +197,21 @@ def kill_workspace(facade: WorkspaceFacade):
     """
     Kill all resources running in a workspace.
     """
-    try:
 
-        name = facade.current()
-
-        # confirm kill
-        click.confirm('{} - Are you sure about killing all {} resources?'.format(
+    name = facade.current()
+    # confirm kill
+    if not click.confirm('{} - Are you sure about killing all {} resources?'.format(
             click.style("Warning", bold=True, fg='yellow'),
             click.style(name, bold=True, fg='red')),
-            abort=True)
-
+            abort=False):
+        click.echo("{} - Workspace {} kill operation aborted. Re-initiate using `{}` if required".format(
+            click.style("Info", bold=True, fg='white'),
+            click.style(name, bold=True, fg='green'),
+            click.style("kaos workspace kill", bold=True, fg='green')))
+        sys.exit(1)
+    else:
         name = facade.delete()
 
         click.echo('{} - Successfully killed all {} resources'.format(
             click.style("Info", bold=True, fg='green'),
             click.style(name, bold=True, fg='green')))
-
-    except Exception as e:
-        handle_specific_exception(e)
-        handle_exception(e)

--- a/docs/getting-started/deploying-infrastructure/README.md
+++ b/docs/getting-started/deploying-infrastructure/README.md
@@ -28,10 +28,10 @@ The current version of kaos supports both [**Local**](local.md) and [**Cloud**](
 
 {% page-ref page="cloud.md" %}
 
-Deploying infrastructure \(regardless of location\) is completed with the same command - `kaos build`. All available options are shown below.
+Deploying infrastructure \(regardless of location\) is completed with the same command - `kaos build deploy`. All available options are shown below.
 
 ```text
-Usage: kaos build [OPTIONS]
+Usage: kaos build deploy [OPTIONS]
 
 Options:
   -c, --cloud [DOCKER|MINIKUBE|AWS|GCP]

--- a/docs/getting-started/deploying-infrastructure/cloud.md
+++ b/docs/getting-started/deploying-infrastructure/cloud.md
@@ -1,7 +1,7 @@
 # Cloud
 
 {% hint style="warning" %}
-Cluster makeup \(instance type and size\) **must** be defined before running `kaos build`
+Cluster makeup \(instance type and size\) **must** be defined before running `kaos build deploy`
 {% endhint %}
 
 Check [AWS](https://aws.amazon.com/ec2/instance-types/) or [GCP](https://cloud.google.com/compute/docs/machine-types) for more details on the available instance types in your respective compute region.
@@ -49,7 +49,7 @@ export AWS_DEFAULT_REGION=#########
 kaos can be built and destroyed within **AWS** with the following commands.
 
 ```bash
-kaos build -c AWS -v
+kaos build deploy -c AWS -v
 kaos destroy -c AWS -v
 ```
 
@@ -123,7 +123,7 @@ export GOOGLE_APPLICATION_CREDENTIALS="</path/to/credential.json>"
 kaos can be built and destroyed within **GCP** with the following commands.
 
 ```bash
-kaos build -c GCP -v
+kaos build deploy -c GCP -v
 kaos destroy -c GCP -v
 ```
 

--- a/docs/getting-started/deploying-infrastructure/local.md
+++ b/docs/getting-started/deploying-infrastructure/local.md
@@ -52,7 +52,7 @@ service/kubernetes   ClusterIP   10.96.0.1    <none>        443/TCP   2m
 Lastly, a **local** kaos cluster with **Docker Desktop** is built and destroyed as follows.
 
 ```bash
-kaos build -c DOCKER -v
+kaos build deploy -c DOCKER -v
 kaos destroy -c DOCKER -v
 ```
 
@@ -65,7 +65,7 @@ kaos destroy -c DOCKER -v
 kaos can be built and destroyed within **minikube** with the following commands.
 
 ```bash
-kaos build -c MINIKUBE -v
+kaos build deploy -c MINIKUBE -v
 kaos destroy -c MINIKUBE -v
 ```
 

--- a/docs/getting-started/installation/linux-install.md
+++ b/docs/getting-started/installation/linux-install.md
@@ -50,7 +50,7 @@ The kaos command-line utility is used for all interactions. It is rather lightwe
   apt-get install graphviz
   ```
 
-* [**docker**](https://docs.docker.com/install/linux/docker-ce/ubuntu/) for dynamic linking of docker registry \(function of `kaos build`\)
+* [**docker**](https://docs.docker.com/install/linux/docker-ce/ubuntu/) for dynamic linking of docker registry \(function of `kaos build deploy`\)
 
   ```bash
   apt-get install docker

--- a/docs/getting-started/installation/macos-install.md
+++ b/docs/getting-started/installation/macos-install.md
@@ -50,7 +50,7 @@ The kaos command-line utility is used for all interactions. It is rather lightwe
   brew install graphviz
   ```
 
-* [**docker**](https://docs.docker.com/install/linux/docker-ce/ubuntu/) for dynamic linking of docker registry \(function of `kaos build`\)
+* [**docker**](https://docs.docker.com/install/linux/docker-ce/ubuntu/) for dynamic linking of docker registry \(function of `kaos build deploy`\)
 
   ```bash
   brew install docker

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -35,14 +35,14 @@ The output from `kaos init` indicates that the user is **successfully connected 
 {% endtab %}
 
 {% tab title="Superhero" %}
-kaos is **not** functional until its infrastructure has been deployed via `kaos build`. Refer to [Deploying Infrastructure](deploying-infrastructure/#local) for additional instructions.
+kaos is **not** functional until its infrastructure has been deployed via `kaos build deploy`. Refer to [Deploying Infrastructure](deploying-infrastructure/#local) for additional instructions.
 
 {% hint style="danger" %}
 Note that the ENV `KAOS_HOME` is **required irrespective of cloud provider.**
 {% endhint %}
 
 ```text
-$ kaos build -c DOCKER -vf
+$ kaos build deploy -c DOCKER -vf
 
 Warning - Performing force build of the backend
 Warning - Are you sure about building kaos backend in DOCKER? [y/N]
@@ -56,7 +56,7 @@ Info - Successfully built kaos environment
 ```
 
 {% hint style="success" %}
-The output from `kaos build` is a **successfully running endpoint**. Note that this endpoint can be shared for collaborative development!
+The output from `kaos build deploy` is a **successfully running endpoint**. Note that this endpoint can be shared for collaborative development!
 {% endhint %}
 
 Further info on sharing a running endpoint is detailed [here](../usage/high-level-usage/infrastructure-deployment.md#sharing-running-endpoint).

--- a/docs/usage/high-level-usage/README.md
+++ b/docs/usage/high-level-usage/README.md
@@ -1,6 +1,6 @@
 # Workflows
 
-kaos is not functional as an ML platform **until it has been deployed in a user-specified cloud environment** \(i.e. via `kaos build`\). Note that `kaos build` is distinct from the _typical_ ML workflow in kaos since it should be done infrequently and with greater knowledge of underlying infrastructure.
+kaos is not functional as an ML platform **until it has been deployed in a user-specified cloud environment** \(i.e. via `kaos build deploy`\). Note that `kaos build deploy` is distinct from the _typical_ ML workflow in kaos since it should be done infrequently and with greater knowledge of underlying infrastructure.
 
 ## kaos Personas
 
@@ -8,14 +8,14 @@ The separation is purposely designed to split the intended user flows - **build*
 
 {% tabs %}
 {% tab title="System Administrator" %}
-**Deploys** kaos infrastructure and generates a running endpoint via `kaos build`
+**Deploys** kaos infrastructure and generates a running endpoint via `kaos build deploy`
 
 * Refer to [Build](infrastructure-deployment.md) for _high level concepts_ related to kaos deployment
 * Refer to [Deploying Infrastructure](../../getting-started/deploying-infrastructure/) for _low level instructions_ on deploying kaos infrastructure
 {% endtab %}
 
 {% tab title="Superhero" %}
-**Deploys** and **interacts** with kaos via `kaos build`
+**Deploys** and **interacts** with kaos via `kaos build deploy`
 
 * Refer to [Build](infrastructure-deployment.md) and [Interact](ml-deployment/) for _high level concepts_
 * Refer to [Deploying Infrastructure](../../getting-started/deploying-infrastructure/) and [Quick Start](../../getting-started/quick-start.md) for _low level instructions_

--- a/docs/usage/high-level-usage/infrastructure-deployment.md
+++ b/docs/usage/high-level-usage/infrastructure-deployment.md
@@ -4,7 +4,7 @@
 
 This involves deploying the underlying infrastructure within the selected compute environment. A running kaos backend \(via an authenticated endpoint\) indicates successful deployment.
 
-The conceptual overview shown below indicates how `kaos build` deploys the entire kaos backend.
+The conceptual overview shown below indicates how `kaos build deploy` deploys the entire kaos backend.
 
 ![](../../.gitbook/assets/kaos_build-1.png)
 
@@ -16,7 +16,7 @@ kaos is **only** available for Data Scientists with a running endpoint!
 
 The kaos deployment portion of the command line interface \(CLI\) consists of the following **two** commands.
 
-* `kaos build`
+* `kaos build deploy`
   * Configure, create and deploy the **kaos** infrastructure backend
 
 {% hint style="info" %}
@@ -34,12 +34,12 @@ The deployed **kaos** infrastructure backend is readily available for sharing wi
 
 ### kaos build
 
-Successfully running `kaos build` will automatically display the current running endpoint on-screen.
+Successfully running `kaos build deploy` will automatically display the current running endpoint on-screen.
 
 In this example, the endpoint is `http://XYZ.amazonaws.com:80/api`.
 
 ```bash
-$ kaos build -c AWS -e dev -vfy
+$ kaos build deploy -c AWS -e dev -vfy
 
 ...
 
@@ -51,7 +51,7 @@ Successfully built kaos [dev] environment
 
 ### kaos config
 
-A kaos configuration file is always present in the current directory under `./kaos/config`. The following file is automatically created after running `kaos build`.
+A kaos configuration file is always present in the current directory under `./kaos/config`. The following file is automatically created after running `kaos build deploy`.
 
 {% tabs %}
 {% tab title="./kaos/config" %}


### PR DESCRIPTION
### Description

When the user confirms as `'N'` to `kaos workspace kill`, an appropriate display message is thrown instead of an unknown exception error.

Resolves bug #83 

### Checklist

- [x] An issue was first created **before** opening this pull request
- [x] The new code follows the kaos [contribution guidelines](CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests to ensure that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
